### PR TITLE
Laravel 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This package can be installed through Composer.
 composer require codewizz/laravel-reddit-api
 ```
 
+If you are using Laravel 5.5+, the service provider and alias will be registered automatically. You can proceed to "[Publish config](#publish-config)".
+
+### Manually register services
+
 You must install this service provider.
 
 ```php
@@ -46,6 +50,8 @@ This package also comes with a facade, which provides an easy way to call the th
     ...
 ];
 ```
+
+### Publish config
 
 You should publish the config file of this package with this command:
 

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": "^7.2",
         "ext-curl": "*",
-        "illuminate/support": "^5.1|^6.0"
+        "illuminate/support": "^5.1|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"
@@ -34,6 +34,16 @@
     "autoload-dev": {
         "psr-4": {
             "CodeWizz\\RedditAPI\\Test\\": "tests"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "CodeWizz\\RedditAPI\\RedditAPIServiceProvider"
+            ],
+            "aliases": {
+                "RedditAPI": "CodeWizz\\RedditAPI\\RedditAPIFacade"
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.2",
         "ext-curl": "*",
-        "illuminate/support": "^5.1|^6.0|^7.0"
+        "illuminate/support": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
Add support for Laravel 6-7. I have removed Laravel 5, and upgraded the PHP requirement to ^7.2, so this should be tagged as `0.2.0`.